### PR TITLE
Create PHP-specific WorkFlow for GitHub actions

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,0 +1,46 @@
+name: Build
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+
+jobs:
+  build:
+    
+    strategy:
+      matrix:
+        php: ['5.4', '5.5', 5.6', '7.0', '7.1', '7.2', '7.3', '7.4']
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Set up PHP environment
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '${{ matrix.php }}'
+        tools: composer
+        extensions: 'xdebug'
+    - uses: actions/checkout@v2
+
+    - name: Install Composer dependencies & cache dependencies
+      uses: "ramsey/composer-install@v2"
+      with:
+        composer-options: "--prefer-dist"
+        custom-cache-key: "{{ runner.os }}-composer-${{ matrix.php }}"
+      env:
+        COMPOSER_ROOT_VERSION: dev-${{ github.event.repository.default_branch }}
+
+    - name: Validate composer.json and composer.lock
+      #run: composer validate --strict  # Currently we’re installing mf2/tests from a commit ref.
+      run: composer validate
+
+    - name: Run Test Suite
+      run: XDEBUG_MODE=coverage ./vendor/bin/phpunit tests --coverage-text
+    
+    #- name: Run Code Sniffer
+    #  run: ./vendor/bin/phpcs
+    
+    #- name: Run Static Analysis
+    #  run: ./vendor/bin/psalm


### PR DESCRIPTION
This just codifies that this is fine from PHP5.4 -> 7.4 👏 using GitHub actions rather than Travis-CI

Even if this library is not actively maintained, I think this helps communicate to potential users.

- I like parts of the API.
- I think the tests are interesting. Especially having recently worked on https://github.com/microformats/php-mf2 which covers the same areas.

https://github.com/Lewiscowles1986/php-microformats/actions/runs/2572399174 from https://github.com/Lewiscowles1986/php-microformats/pull/1 shows the action passing (which, I won't lie. Surprised me)